### PR TITLE
inserted Session's 'required' field and removed 'unique' instead

### DIFF
--- a/models/sessions.js
+++ b/models/sessions.js
@@ -8,7 +8,7 @@ const Session = mongoose.model('Session', new mongoose.Schema({
     },
     username: {
 	type: String,
-	unique: true
+	required: true,
     },
     createdAt: {
 	type: Date,


### PR DESCRIPTION
Accidentally removed the wrong field. The idea is to allow users to have multiple sessions up at a single time. This way we avoid the problem of locking someone out of the site for 10 minutes (described in the security report in more detail).